### PR TITLE
Testing

### DIFF
--- a/DATA.m3u
+++ b/DATA.m3u
@@ -1,0 +1,18 @@
+#EXTM3U
+
+#EXTINF:487,Like Ships Without Anchors.mp3
+/home/reprise/Music/ytdl-downloads/Like Ships Without Anchors.mp3
+#EXTINF:285,Snowdance - Vanilla.mp3
+/home/reprise/Music/ytdl-downloads/Snowdance - Vanilla.mp3
+#EXTINF:246,Lift Me Up - Five Finger Death Punch.mp3
+/home/reprise/Music/ytdl-downloads/Lift Me Up - Five Finger Death Punch.mp3
+#EXTINF:325,Dissapear in Light.mp3
+/home/reprise/Music/ytdl-downloads/Dissapear in Light.mp3
+#EXTINF:270,Street Spirit (Fade Out).mp3
+/home/reprise/Music/ytdl-downloads/Street Spirit (Fade Out).mp3
+#EXTINF:378,Carry me Ohio - Sun Kil Moon.mp3
+/home/reprise/Music/ytdl-downloads/Carry me Ohio - Sun Kil Moon.mp3
+#EXTINF:238,Outrun.mp3
+/home/reprise/Music/ytdl-downloads/Outrun.mp3
+#EXTINF:451,Carry Me Ohio (Cover).mp3
+/home/reprise/Music/ytdl-downloads/Carry Me Ohio (Cover).mp3

--- a/DATA.m3u
+++ b/DATA.m3u
@@ -1,5 +1,11 @@
 #EXTM3U
 
+#EXTINF:#EXTINF:253,Radio - Le Cassette.mp3
+/home/reprise/Music/ytdl-downloads/Radio - Le Cassette.mp3
+#EXTINF:283,This Is All We Know.mp3
+/home/reprise/Music/ytdl-downloads/This Is All We Know.mp3
+#EXTINF:238,International Karate.mp3
+/home/reprise/Music/ytdl-downloads/International Karate.mp3
 #EXTINF:487,Like Ships Without Anchors.mp3
 /home/reprise/Music/ytdl-downloads/Like Ships Without Anchors.mp3
 #EXTINF:285,Snowdance - Vanilla.mp3
@@ -14,5 +20,7 @@
 /home/reprise/Music/ytdl-downloads/Carry me Ohio - Sun Kil Moon.mp3
 #EXTINF:238,Outrun.mp3
 /home/reprise/Music/ytdl-downloads/Outrun.mp3
+#EXTINF:300,Feel It.mp3
+/home/reprise/Music/ytdl-downloads/Feel It.mp3
 #EXTINF:451,Carry Me Ohio (Cover).mp3
 /home/reprise/Music/ytdl-downloads/Carry Me Ohio (Cover).mp3

--- a/install.sh
+++ b/install.sh
@@ -4,54 +4,92 @@
 #DATE: 4.28.2016
 
 #PURPOSE:
-#This script moves the files of ytdl to the correct locatons, and changes the 
+#This script moves the files of ytdl to the correct locatons, and changes the
 #permissions of the files in ~/Music so that users other than root can access them.
 #root permissions are needed to write to /usr/bin.
 #This script installs ytdl v1.10+.
 
-#Version 1.01
+#Version 1.3.0
 #===================================================================================
+opt=$1
+case "$opt" in
+      # RUN AS AN UPDATER (needs work)
+      -u|--update)
+            #need to be root for this too, because copying to /usr/bin.
+            if [[ $EUID -ne 0 ]]; then
+                  echo "This script must be run as root in order to write to /usr/bin." 1>&2
+                  exit 1
 
-FILE="/tmp/out.$$"
-GREP="/bin/grep"
-wd=$(pwd)
+            #Yes? Install time.
+            else
+                  #finding out what user we're installing to, since ~/ will return /home/root.
+                  me=$(readlink -f install.sh | cut -f3 -d '/')
+                  me=$(echo /home/$me)
 
-# Are we root?
-if [[ $EUID -ne 0 ]]; then
-      echo "This script must be run as root" 1>&2
-      exit 1
+                  #get files from github, then put the new copy of ytdl in place.
+                  cd $me/Desktop
+                  echo "Downloading..."
+                  git clone https://github.com/reprise5/ytdl
+                  cd ytdl
 
-#Yes? Install time.
-else   
-      #finding out what user we're installing to, since ~/ will return /home/root.
-      me=$(readlink -f install.sh | cut -f3 -d '/')
-      echo "Installing to user: '$me'"
-      me=$(echo /home/$me)
+                  echo "Giving execute permissions to'ytdl.sh'"
+                  chmod a+x ytdl.sh
 
-      #Ok, move files and set correct permissions.
-      echo "creating $me/Music/ytdl-downloads"
-      mkdir $me/Music/ytdl-downloads
+                  # Won't work unless YTDL can be run as root.
+                  installedVersion=$(ytdl --version | cut -d ' ' -f 3)
+                  thisVersion=$(./ytdl.sh --version)
+                  echo "installedVersion: $installedVersion thisVersion $thisVersion"
 
-      echo "setting permissions for '$me/Music/ytdl-downloads'"
-      chmod a+rwx $me/Music/ytdl-downloads
+                  if [[ thisVersion != installedVersion ]]; then
+                        echo "moving ytdl.sh to /usr/bin..."
+                        cp ytdl.sh /usr/bin
+                        mv /usr/bin/ytdl.sh /usr/bin/ytdl
+                  fi
 
-      echo "moving help page to $me/Music/ytdl-downloads"  
-      cp ytdl-help.txt $me/Music/ytdl-downloads
+                  cd ..
+                  rm -rf ytdl
+            fi
 
-      echo "Changing permissions for '$me/ytdl-downloads/ytdl-help.txt'"
-      chmod a+rwx $me/Music/ytdl-downloads/ytdl-help.txt
+            if [ -t 1 ]; then
+                  tput setaf 1; echo -e "[ !! ] \c"
+                  tput sgr0   ; echo -e "There was an error while updating ytdl."
 
-      echo "moving ytdl to /usr/bin"
-      mv ytdl.sh ytdl
-      cp ytdl /usr/bin
-      
-      echo "changing permissions of 'ytdl.sh'"
-      chmod a+rwx /usr/bin/ytdl      
+            else
+                  tput setaf 2; echo -e "[ OK ] \c"
+                  tput sgr0   ; echo -e "UP-TO-DATE"
+            fi
+            ;;
+      # RUN AS AN INSTALLER. (first time install)
+      *)
+            # Are we root?
+            if [[ $EUID -ne 0 ]]; then
+                  echo "This script must be run as root in order to write to /usr/bin." 1>&2
+                  exit 1
 
-      mv ytdl ytdl.sh
+            #Yes? Install time.
+            else
+                  # Finding out what user we're installing to, since ~/ will return /home/root.
+                  me=$(readlink -f install.sh | cut -f3 -d '/')
+                  me=$(echo /home/$me)
 
-      #ending message:
-      tput setaf 2; echo -e "[ OK ] \c"
-      tput sgr0   ; echo -e "Done!  Enjoy ytdl!"
-fi
+                  #Ok, move files and set correct permissions.
+                  echo "creating $me/Music/ytdl-downloads"
+                  mkdir $me/Music/ytdl-downloads
 
+                  echo "setting permissions for '$me/Music/ytdl-downloads'"
+                  chmod a+rwx $me/Music/ytdl-downloads
+
+                  echo "moving ytdl & playlist to /usr/bin"
+                  mv ytdl.sh /usr/bin/ytdl
+                  mv playlist.py /usr/bin/playlist
+
+                  echo "Giving execute permissions to'ytdl.sh' and 'playlist.py'."
+                  chmod a+x /usr/bin/ytdl
+                  chmod a+x /usr/bin/playlist
+
+                  #ending message:
+                  tput setaf 2; echo -e "[ OK ] \c"
+                  tput sgr0   ; echo -e "Done!  Enjoy ytdl!"
+            fi
+            ;;
+esac

--- a/playlist.py
+++ b/playlist.py
@@ -2,7 +2,7 @@
 '''
 AUTHOR: Reprise
 DATE: 05.18.17
-Version: 1.0.0
+Version: 1.0.1
 
 PURPOSE:
 This program is meant to create .m3u entries to assist in the creation of playlists.
@@ -34,16 +34,19 @@ for track in os.listdir(PATH):
     # Write entry as it should appear in playlist
     playlist.write(FILE_MARKER + ":")
 
-    # Write RUNTIME
-    audio = MP3(path_track)
-    runtime = audio.info.length
-    playlist.write(str(runtime)[0:3])
-    playlist.write("," + track + "\n")
+    # DATA.m3u will be in this directory, we don't want to process it.
+    if track != "DATA.m3u":
 
-    # write path.
-    playlist.write(path_track + "\n")
+        # Write RUNTIME
+        audio = MP3(path_track)
+        runtime = audio.info.length
+        playlist.write(str(runtime)[0:3])
+        playlist.write("," + track + "\n")
 
-    print("entry created: " + track)
+        # write path.
+        playlist.write(path_track + "\n")
+
+        print("entry created: " + track)
 
 playlist.close()
 

--- a/playlist.py
+++ b/playlist.py
@@ -2,30 +2,36 @@
 '''
 AUTHOR: Reprise
 DATE: 05.18.17
+Version: 1.0.0
 
 PURPOSE:
 This program is meant to create .m3u entries to assist in the creation of playlists.
 While this program does not allow a user-specified ordering, the user can take the entries
-and order them themselves.
-
-Version: 1.0.0
+and order them themselves.  it is meant to be called from 'ytdl' which will give it a path as an argument.
+the path should be where the playlist is to be created.
 '''
 
 import os
+import sys
+import re
 from mutagen.mp3 import MP3
+
+if len(sys.argv) < 2:
+    print("Invalid path to directory.")
+    exit(0)
 
 FORMAT_DESCRIPTOR = "#EXTM3U"
 FILE_MARKER = "#EXTINF"
-PATH = '/home/reprise/Music/ytdl-downloads'
+PATH = sys.argv[1]  # This should be given by ytdl.
 filename = "DATA.m3u"
 
 playlist = open(filename, 'w')
 playlist.write(FORMAT_DESCRIPTOR + "\n\n")
-                        #os.getcwd()
+
 for track in os.listdir(PATH):
     path_track = PATH + "/" + track
 
-    #Write entry as it should appear in playlist
+    # Write entry as it should appear in playlist
     playlist.write(FILE_MARKER + ":")
 
     # Write RUNTIME
@@ -34,11 +40,12 @@ for track in os.listdir(PATH):
     playlist.write(str(runtime)[0:3])
     playlist.write("," + track + "\n")
 
-    #write path.
+    # write path.
     playlist.write(path_track + "\n")
+
+    print("entry created: " + track)
 
 playlist.close()
 
-# Left to do: The directory this program is run in should be the ROOT directory, and any music
-# Found in subdirectories should have a path. The goal was not to have absolute paths.
-
+# TODO : The directory this program is run in should be the ROOT music directory.  The goal was not to have absolute paths.
+# TODO : Find music in recursive directories, and understand their path from the root folder, being argv[1]. (walk?)

--- a/ytdl.sh
+++ b/ytdl.sh
@@ -8,14 +8,13 @@
 #it assumes you have no other .m4a files in the dir.
 #Syntax: ytdl [OPTIONS] [URL]  *an option is required. Arguement isn't.
 
-#Version: 1.2.2
+#Version: 1.3.0
 #===================================================================================
-VERSION="1.2.2"   #Variable holds the version.  when updating, change it here.
+VERSION="1.3.0"   #Variable holds the version.  when updating, change it here.
 opt=$1            #first option, which should be -u, -v, or -h.
 URL=$2            #arguement to go with option1, namely -u.
 opt2=$3           #option 2, reserved only for -t at this time.
 ME=$(echo ~/)     #home directory
-ANS=""            #Is used for y/n answers for questions.
 infile=""         #filename with underscores for avconv's standard input requirement
 outfile=""        #as above, but the output name while callling avconv
 TITLE=""          #for writing ID3 tags.  user inputs, taken in with read statements.
@@ -48,8 +47,10 @@ OPTIONS:
                         SYNTAX: ytdl -u 'URL' -t or ytdl -t filename.mp3.
                         will only change tags for music in ytdl-downloads folder.
 
-      -l, --list        List the music you've already downloaded with ytdl.  Music resides
+      -ls, --list        List the music youve already downloaded with ytdl.  Music resides
                         in ~/Music/ytdl-downloads.
+      --playlist        Creates a playlist in ${ME}Music/ytdl-downloads.  if you specify
+                        a path as an arguement, a playlist will be made there instead.
 
       -h , --help       Display this help menu.
 
@@ -165,7 +166,7 @@ case "$opt" in
             #so that -u and -t can be used at the same time.
             case "$opt2" in
                   -t|--mktag)
-                         make_ID3_tags
+                        make_ID3_tags
                    ;;
             esac
             ;;
@@ -180,10 +181,17 @@ case "$opt" in
       --version)
             echo "Version: " $VERSION
             ;;
-      -l|--list)
+      -ls|--list)
             cd ~/Music/ytdl-downloads/
             echo -e "\n        >>>>>]DOWNLOADED FILES[<<<<<"
             ls -lAh | awk '{$1=$2=$3=$4=$6=$7=$8=""; print $0}'
+            ;;
+      -p|--playlist)
+            # test for args.  if no then,
+            if [ -z $2 ]; then
+                  playlist {$ME}Music/ytdl-downloads/
+            fi
+            playlist $2
             ;;
       *|-h|--help)
             display_help

--- a/ytdl.sh
+++ b/ytdl.sh
@@ -187,11 +187,13 @@ case "$opt" in
             ls -lAh | awk '{$1=$2=$3=$4=$6=$7=$8=""; print $0}'
             ;;
       -p|--playlist)
-            # test for args.  if no then,
+            #if it's zero length, use ytdl-downloads by default. otherwise use user's path.
             if [ -z $2 ]; then
-                  playlist {$ME}Music/ytdl-downloads/
+                  playlist ~/Music/ytdl-downloads/
+            else
+                  playlist $2
             fi
-            playlist $2
+
             ;;
       *|-h|--help)
             display_help


### PR DESCRIPTION
### Changes
*  Playlist.py skips over DATA.m3u do it doesn't matter where the file is created.  Prevents playlist.py from crashing.
*  playlist.py is called from ytdl.sh with the --playlist option.  a user has the option to add a path to the directory with music in it they want to make a playlist out of.  if none is specified, ytdl automatically tells playlist.py to use ~/Music/ytdl-downloads.

### To-Do
*  Cannot go into subdirectories yet.
*  Can only process .mp3 entries now.  Add support for .ogg, .flag, .wav.
    *  look at each file's extension.  skip over anything that's not .mp3, .ogg, .flac, or .wav.  if they fit 
        these types, process them by their type.