### PR TITLE
fixed --mktag, resolves #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ cd ytdl
 ```
 next change the permissions of install.sh, and run it.
 ```
-chmod 775 install.sh
+chmod +x install.sh
 ./install.sh
 ```
 And you're done!
@@ -48,7 +48,7 @@ git clone https://github.com/reprise5/ytdl
 Move to the new directory with the downloaded files, rename ytdl.sh to ytdl, and add permissions.
 ```
 cd ytdl
-chmod 775 ytdl.sh
+chmod +x ytdl.sh
 mv ytdl.sh ytdl
 ```
 Then put a copy of the ytdl file to /usr/bin.
@@ -63,22 +63,31 @@ If you followed the previously mentioned steps for installing, simply run the sc
 ytdl has a few options:
 ```
       --version         Displays which version of ytdl this is.
+
       -u, --url [URL]   will download and convert a YouTube stream normally.
                         The output goes to ${ME}Music/ytdl-downloads.
+
       -t, --mktag       Gives you the option to write title and artist ID3 Tags.  will also rename
                         the filename with the information you give.  do not give null values.
-                        SYNTAX: ytdl -u 'URL' -t            -t must come after -u 'URL'.
+                        SYNTAX: ytdl -u 'URL' -t or ytdl -t filename.mp3.
+                        will only change tags for music in ytdl-downloads folder.
+
+      -l, --list        List the music youve already downloaded with ytdl.  Music resides
+                        in ~/Music/ytdl-downloads.
+      --playlist        Creates a playlist in ${ME}Music/ytdl-downloads.  if you specify
+                        a path as an arguement, a playlist will be made there instead.
+
       -h , --help       Display this help menu.
 ```
 
 ###### 2:
-If you don't want to put the file in /bin you can just run it as-is.
+If you don't want to put the file in /usr/bin you can just run it as-is.
 Assuming you didn't follow the installation steps for ytdl above:
 ```
 cd ~/Desktop
 git clone https://github.com/reprise5/ytdl
 cd ytdl
-chmod 775 ytdl.sh
+chmod +x ytdl.sh
 ```
 And then run the script:
 `./ytdl.sh -u 'https://www.youtube.com/ASDFGHJKL' -t

--- a/changelog.md
+++ b/changelog.md
@@ -175,14 +175,20 @@ Initial release
 - Dependency checks in installer script.
 - instead of avoiding youtube playlists, can you embrace it?
 
-## [1.3.3] - 2018-01-20
+## [1.3.4] - 2018-02-13
+`commit 7475a2de19d14aef66e3050acc0524c7ba0cfc25`
+`commit `
+`merge `
 
-#### Changed
+#### Fixed
 - --mktag option uses its own mktag routine instead of trying to reuse the one used post-download in  what I call "normal processing" (downloading a stream, and converting.  certain variables populate this way.)
-- this new routine uses local variables for title/artist, which are taken in as args instead of read statements like in "normal processing."
+    - This change fixes issue #3.
+    - this new routine uses local variables for title/artist, which are taken in as args instead of read statements like in "normal processing."
+
+#### Added
  - checks for eyeD3's existence here because it's not going through make_ID3_tags() routine anymore.
+
 #### TODO
-- continue to fix --mktag to rename the file after tags are written.
 - rewrite make_ID3_tags to be able to receive arguments the same way --mktag does.
 - Dependency checks in installer script.
 - Detect non-english computer and install ytdl correctly.

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,188 @@
+```
+                                  ██╗   ██╗████████╗██████╗ ██╗
+                                  ╚██╗ ██╔╝╚══██╔══╝██╔══██╗██║
+                         █████╗    ╚████╔╝    ██║   ██║  ██║██║      █████╗
+                         ╚════╝     ╚██╔╝     ██║   ██║  ██║██║      ╚════╝
+                                     ██║      ██║   ██████╔╝███████╗
+                                     ╚═╝      ╚═╝   ╚═════╝ ╚══════╝                                                      
+```
+## [1.0.0] - 2016-04-20
+`commit 6b1278349426274e1b3de709197055a818eabe3c`
+
+Initial release
+
+## [1.0.1] - 2016-04-20
+#### Changed
+- Changed the ordering of the commands for readability.
+- Changed comments
+
+#### TODO:
+- Options, and pass URL as an arguement.
+- Split up the code so it can be called from subroutines to make it into a case structure.  for options.     
+
+## [1.0.2] - 2016-04-21
+#### Added
+- Added colors for [ OK ] , [ERROR] and "converting..." messages in the output.
+- Added more conditional statements to handle more errors and problems, and better tell the user what's wrong.
+- Added newline characters in echo to reduce filesize.
+- Added a printed path to output (working directory) when displaying the filename when done.
+
+#### Changed
+- Separated youtube-dl & avconv calls into functions.
+  - Split up the code so it can be called from subroutines to make it into a case structure for options.
+- User puts URL on the same line as the message now.  Not a new line.
+  - However it is still not passed as an arguement.  Using a read statement still.
+
+#### TODO:
+- Options, and pass URL as an arguement.
+- Make case structure for passing arguements with options.
+
+## [1.0.3] - 2016-04-26
+`commit 9b0adad3e2994fa6fbf99e6aa1824cb9ad719277`
+
+#### Changed
+- Can now pass the URL as an arguement when running the script
+- Echo syntax using ""
+#### Added
+- Make a seperate folder called "ytdl-downloads" If it doesn't exist already.  Make it the default Download location.
+  - In order to go around the *.m4a issue that may arise from other people having those files in `~/Music`.
+
+#### TODO:
+- use getopts and make options to pass as well as the arguement.
+    - Let format be [OPTIONS] [ARGUEMENT(S)].
+    - One of these options will be mktag, which will be a new subroutine.
+    - Use all of the standard opts like -h --help, &etc.
+    - Edit the readme.
+## [1.1.0] - 2016-04-28
+`commit 33751e72970d842ad5c1c376445c65e2f877a754`
+#### Added
+- Added a case structure that allows the user to pass options AND arguements!
+    - Currently `-h (help)`, `-u [url] (normal processing)`, and `-k --keep-original [url]` (keeps original *.m4a file after processing.)
+- Checks if the user is root.  If they are the script won't run.
+- Added `get_help()` functon.
+- Added a `--help` page.  It's a seperate file that the script calls using cat. In the `get_help()` function.
+- Added an installer that requires root to run.
+    - Checks who it should install to
+    - Makes ytdl-downloads folder in ~/Music, puts ytdl-help.txt in it.
+    - Puts ytdl.sh in /bin without the extension
+    - Changes permissions to the items made in ~/Music because root made them originally.
+#### Changed
+- Moved the pre-avconv code in the get_stream() function.  
+    - The code that looks for unconverted, cuts the extension off it, and adds underscores.
+
+#### TODO:
+- Add more Options
+- Finish -k option
+- Add options that allow the user to chose converted filetype.  We'd just change how we call avconv, no big deal.  Only have to complely change how conv_stream() works.
+- Maybe have the wildcard (*) option in the case perform regular processing instead of -u.  So the user can just call ytdl [URL] with no opts.
+
+## [1.1.1] - 2016-09-29
+`commit 4e2364e3e5cc0b5206a5850bc740ed71b1bfe094`
+#### Fixed
+- Color changed back to normal after "converting to MP3" Message
+- Help Text such as usage and avconv/youtube-dl info is no longer printed to the screen using cat from a file. The text is inside the script, which eliminates the need for ytdl-help.txt.
+- Version option `--version` was added.  Echoes a variable `$VERSION`.
+
+## [1.1.2] - 2016-10-19
+`commits e9d5ca855c8e4bf6a527d5613c2ba0f83aabb2ee, 994182489233a0c20df381af6361a18a578bb1ff`
+
+#### Removed
+- Removed Get_multi_stream() function.
+
+#### Changed
+- Changed Variable print in echo statement:
+	- `$ME Music/ytdl-downloads` to `${ME}Music/ytdl-downloads`
+    - This ^ used to have the output /home/user/ Music/ytdl-downloads, and now has the output /home/user/Music/ytdl-downloads.
+
+
+## [1.2.0] - 2016-10-20
+`commit 6d7e6f12d03c2158323aee1aa08749f5ca05b740`
+
+#### Added
+- After normal processing takes place in `-u`, and `-t` option is appended, then ID3 Tags sub will be invoked.  it will prompt the user for TITLE and ARTIST only.
+	- Uses read statements right now.
+    - If eyeD3 is not present, prompts the user if they would like to install it right there. If they say yes, it will use python pip.
+    - The bones are there to just call ytdl -t filename.mp3 to invoke the make_ID3_tag sub and write tags if you changed your mind after processing.  still Work in progress.
+- Looks at the URL to see if it points to a playlist on YouTube.  if it does, it tells the user
+       the issue and quits itself.  
+	- YTDL cannot handle multiple .m4a files in the same dir.  this prevents this from happening by accident. the pattern is "\*&list=\*".
+
+#### TODO:
+- Change installer to prompt user to install avconv, ytdl, and eyeD3 and do so as directed instead of the main ytdl script handling that.  Split the jobs.
+- Multi_stream() function to GET using "\*&list=\*" URLs, and storing the NAMES in an array. when it is time to process, it pulls the first name in the array by ELEMENT not by .m4a, and assign it to $unconverted variable.  It's literally the perfect idea.
+- How will -t work in this sense???  
+	- If you learn getopts?
+## [1.2.1] - 2017-03-25
+
+#### Added
+- Added ability to add ID3 tags. Uses read statements and prompts for artist & title.
+	- Writing ID3 tags inplicitly renames file using the above information.
+## [1.2.2] - 2017-05-08
+
+#### Added
+- File listing is available with the option `-ls` or `--list`.  Specifies the file size in Megs, as well as the name of the file right next to it.
+
+#### Removed
+- Removed prompts that try to install eyed3 through pip.
+
+## [1.3.0] - 2017-06-23
+`commit 0c49ef7fb08b92fcf04af8a3a17696acd9cfe6ff`
+- Merged testing branch with master.  Below changes are functional.
+
+#### Added
+- Added the ability to create .m3u playlist entries from a python script "playlist.py".
+	- Playlist.py is called from ytdl and can recieve a specific path to be sent to playlist.py for it to create entries in that specific directory.  If no directory is specified, ytdl will just send over ~/Music/ytdl-downloads as a default.
+	- Skips procesing of the .m3u file it creates.  Can only process MP3 files now.
+
+#### TODO:
+- Walk into subdirectories.
+	- Skip by extension.
+    - Be able to process .ogg, .flac, and .wav files as well as just .mp3.  Do this by checking the extension to determine which mutagen mod to use.
+    - Do not include full path in m3u entries. if it walks into a subdir, then start tracking paths.
+
+## [1.3.1] - 2017-08-17
+`commit 3a41af76e7819976cc70bbde6c840fbe1dbb289f`
+#### Fixed
+- Print file marker exclusively when a record is being written. (oversight).
+
+## [1.3.2] - 2017-10-5
+
+#### Changed
+- Check for youtube-dl file in both /usr/bin and /usr/local/bin.
+- Clarified error messages for missing dependencies.
+	- avconv comes from libav-tools package.
+
+#### TODO
+- Dependency checks in installer script.
+- Problems:
+	- When installing to computers running different languages, ~/Music was not a destination for example. Maybe if non-english, put ytdl-downloads in ~ instead.
+	- with Different/newer versions of libav/ffmpeg, youtube-dl threw some errors about depricated features. (on its own, without options.) Did not throw errors from ytdl.
+
+## [1.3.3] - 2018-01-20
+
+#### Changed
+- ytdl.sh
+    - Parse $URL input to check for playlist, and take URL text up to the first "&" for current video.
+        - this option in the if/else structure now calls get_stream().
+    - changed -ls option to -l.  Updated in help text and case structure.
+    - Drew Blob Jr.
+- README
+    - reflects changes in help text
+    - chmod 775 changed to +x
+    - all instances of /bin changed to /usr/bin
+
+#### TODO
+- Dependency checks in installer script.
+- instead of avoiding youtube playlists, can you embrace it?
+
+## [1.3.3] - 2018-01-20
+
+#### Changed
+- --mktag option uses its own mktag routine instead of trying to reuse the one used post-download in  what I call "normal processing" (downloading a stream, and converting.  certain variables populate this way.)
+- this new routine uses local variables for title/artist, which are taken in as args instead of read statements like in "normal processing."
+ - checks for eyeD3's existence here because it's not going through make_ID3_tags() routine anymore.
+#### TODO
+- continue to fix --mktag to rename the file after tags are written.
+- rewrite make_ID3_tags to be able to receive arguments the same way --mktag does.
+- Dependency checks in installer script.
+- Detect non-english computer and install ytdl correctly.

--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,7 @@
 #root permissions are needed to write to /usr/bin.
 #This script installs ytdl v1.10+.
 
-#Version 1.3.0
+#Version 1.3.1
 #===================================================================================
 opt=$1
 case "$opt" in

--- a/parseURL.sh
+++ b/parseURL.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+#AUTHOR: Reprise
+#DATE: 2018.01.20
+#      yyyy/mm/dd
+
+#PURPOSE:
+#This is used to debug parsing of URL in YTDL.
+#Tab witdh here is 4.  tab width 6 in ytdl.
+
+#Version: 1.3.3
+
+URL=$1           
+
+if [[ $URL == *"&list="* ]]; then
+    echo "this URL points to a playlist.  Taking current video."
+    #Parse text & take URL up to first "&" being "&list=" which points to playlist.
+    URL=$(echo $URL | awk 'BEGIN { FS="&" } /1/ { print $1 }')
+    echo "URL is $URL"
+
+elif [[ -n $URL ]]; then
+    #get_stream "$URL"\c
+    echo "Stream does not contain \"&list=\"." 
+else
+    echo -e "Please enter a valid URL."
+    exit 0
+fi
+
+
+#                              Sample Output
+#┌─(~/Desktop/ytdl)─────────────────────────────────────(reprise@Enkidu:pts/0)─┐
+#└─(16:59:47─> ./ytdlParse.sh AA&BB                        127 ↵ ──(Sat,Jan20)─┘
+#[1] 25118
+#zsh: command not found: BB
+#Stream does not contain "&list=".                                                                           
+#┌─(~/Desktop/ytdl)─────────────────────────────────────(reprise@Enkidu:pts/0)─┐
+#└─(17:00:57─>                                             127 ↵ ──(Sat,Jan20)─┘
+#[1]  + done       ./ytdlParse.sh AA
+

--- a/playlist.py
+++ b/playlist.py
@@ -2,12 +2,11 @@
 '''
 AUTHOR: Reprise
 DATE: 05.18.17
-Version: 1.0.1
+Version: 1.0.2
 
 PURPOSE:
 This program is meant to create .m3u entries to assist in the creation of playlists.
-While this program does not allow a user-specified ordering, the user can take the entries
-and order them themselves.  it is meant to be called from 'ytdl' which will give it a path as an argument.
+It is meant to be called from 'ytdl.sh', which will give it a path as an argument.
 the path should be where the playlist is to be created.
 '''
 
@@ -16,26 +15,28 @@ import sys
 import re
 from mutagen.mp3 import MP3
 
-if len(sys.argv) < 2:
-    print("Invalid path to directory.")
-    exit(0)
-
 FORMAT_DESCRIPTOR = "#EXTM3U"
 FILE_MARKER = "#EXTINF"
 PATH = sys.argv[1]  # This should be given by ytdl.
 filename = "DATA.m3u"
 
+# Check for path in which to find files to make into a playlist.
+if len(sys.argv) < 2:
+    print("Invalid path to directory.")
+    exit(0)
+
+# Create, open, and set header for playlist file.
 playlist = open(filename, 'w')
 playlist.write(FORMAT_DESCRIPTOR + "\n\n")
 
 for track in os.listdir(PATH):
     path_track = PATH + "/" + track
 
-    # Write entry as it should appear in playlist
-    playlist.write(FILE_MARKER + ":")
-
     # DATA.m3u will be in this directory, we don't want to process it.
-    if track != "DATA.m3u":
+    if track != filename:
+
+        # Write entry as it should appear in playlist
+        playlist.write(FILE_MARKER + ":")
 
         # Write RUNTIME
         audio = MP3(path_track)
@@ -45,10 +46,9 @@ for track in os.listdir(PATH):
 
         # write path.
         playlist.write(path_track + "\n")
-
         print("entry created: " + track)
 
 playlist.close()
 
-# TODO : The directory this program is run in should be the ROOT music directory.  The goal was not to have absolute paths.
-# TODO : Find music in recursive directories, and understand their path from the root folder, being argv[1]. (walk?)
+# TODO : Do not record paths from root dir. If this walks into sub-folders, start recording path from cwd.
+# TODO : Find music in recursive directories (walk), and understand their path from argv[1] Dir. 

--- a/ytdl.sh
+++ b/ytdl.sh
@@ -180,13 +180,10 @@ case "$opt" in
                   eyeD3 -t $title -a $artist "$file"
                   echo "processing \"$file\" with title $title and artist $artist in $(pwd)."
 
-                  #implicit rename. Hard-coded extension appended to ARTIST because
-                  #this script explicitly converts to *.mp3.
-#      FIX FILE RENAME ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓
-#                 artist=$(echo ${artist}.mp3)          ←
-#                 mv '$file' '$title - $artist'         ←
-#                 echo " '$file' '$title - $artist'"    ←
-#      FIX FILE RENAME ↑ ↑ ↑ ↑ ↑ ↑ ↑ ↑ ↑ ↑ ↑ ↑ ↑ ↑ ↑ ↑ ↑
+                  #rename the file to reflect tags.  hard-coded extension appended to artist.
+                  artist=$(echo ${artist}.mp3)
+                  mv "$file" "$title - $artist" #rename
+                  echo "$file $title-$artist"
             else
                   echo "please install \"eyeD3\" through python pip."
             fi
@@ -206,7 +203,6 @@ case "$opt" in
             else
                   playlist $2
             fi
-
             ;;
       *|-h|--help)
             display_help

--- a/ytdl.sh
+++ b/ytdl.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 
 #AUTHOR: Reprise
-#DATE: 10.20.2016
+#DATE: 10.5.2017
 
 #PURPOSE:
 #This script grabs a stream off youtube, then converts it to mp3.
 #it assumes you have no other .m4a files in the dir.
-#Syntax: ytdl [OPTIONS] [URL]  *an option is required. Arguement isn't.
+#Syntax: ytdl [OPTIONS] [URL]  *an option is required. Argument isn't.
 
-#Version: 1.3.0
+#Version: 1.3.4
 #===================================================================================
-VERSION="1.3.0"   #Variable holds the version.  when updating, change it here.
+VERSION="1.3.4"   #Variable holds the version.  when updating, change it here.
 opt=$1            #first option, which should be -u, -v, or -h.
 URL=$2            #arguement to go with option1, namely -u.
 opt2=$3           #option 2, reserved only for -t at this time.
@@ -44,25 +44,24 @@ OPTIONS:
 
       -t, --mktag       Gives you the option to write title and artist ID3 Tags.  will also rename
                         the filename with the information you give.  do not give null values.
-                        SYNTAX: ytdl -u 'URL' -t or ytdl -t filename.mp3.
-                        will only change tags for music in ytdl-downloads folder.
+                        SYNTAX: ytdl -u 'URL' -t song artist
+                                ytdl -t filename.mp3 song artist
 
-      -ls, --list        List the music youve already downloaded with ytdl.  Music resides
+      -l, --list        List the music youve already downloaded with ytdl.  Music resides
                         in ~/Music/ytdl-downloads.
       --playlist        Creates a playlist in ${ME}Music/ytdl-downloads.  if you specify
                         a path as an arguement, a playlist will be made there instead.
 
       -h , --help       Display this help menu.
-
 EOF
 }
 
 get_stream() {
       #check Youtube-dl's existence
-      if [ -f /usr/bin/youtube-dl ]; then
+      if [[ -f /usr/local/bin/youtube-dl || -f /usr/bin/youtube-dl ]]; then
             youtube-dl --extract-audio -f 140 $URL  -o '%(title)s.%(ext)s' --no-playlist --restrict-filenames
       else
-            echo "please install youtube-dl to grab this stream."
+            echo "please install youtube-dl through python-pip to grab this stream."
             exit 1
       fi
 
@@ -71,7 +70,7 @@ get_stream() {
       if [ "$unconverted" = "" ]; then
             #Download Failed from youtube-dl.
             tput setaf 1; echo -e "[ERROR] \c"
-            tput sgr0   ; echo -e "Download failed. \nexiting early.\n"
+            tput sgr0   ; echo -e "Download failed. exiting early.\n"
             exit 1
       else
             #Youtube-dl successfully grabbed the stream.
@@ -92,15 +91,14 @@ conv_stream() {
             tput sgr0   ;
             avconv -i $infile $outfile
       else
-            echo "please install avconv to convert this stream."
+            echo "please install the package 'libav-tools' to convert this stream."
             exit 1
       fi
 }
 
 make_ID3_tags() {
-
       if [ -f /usr/bin/eyeD3 ]; then
-            cd cd ~/Music/ytdl-downloads
+            cd ~/Music/ytdl-downloads
             tput setaf 2; echo -e "Writing Basic ID3 Tags for SONG-TITLE and ARTIST."
             tput sgr0   ; echo -e "TITLE:\c"
             read "TITLE"
@@ -112,12 +110,12 @@ make_ID3_tags() {
             #implicit rename. Hard-coded extension appended to ARTIST.
             ARTIST=$(echo ${ARTIST}.mp3)
             mv $outfile "$TITLE - $ARTIST"
-       fi
+      fi
 }
 #Are you root?
 if [ "$EUID" -eq 0 ]
-  then echo "Please don't run this as root."
-  exit 0
+      then echo "Please don't run this as root."
+      exit 0
 fi
 
 #Check if ~/Music/ytdl-downloads exists.  It's the working directory.
@@ -136,17 +134,16 @@ fi
 #I don't know how to use getopts.  ;(
 
 case "$opt" in
-        -u|--url)
+      -u|--url)
             #check $URL for formatting/existence.
             if [[ $URL == *"&list="* ]]; then
-                  echo "this URL points to a playlist.  Please provide a URL to a single YouTube video."
-                  echo "This script cannot handle multi-file processing.  Exiting..."
-                  exit 0
-                  #maybe put the variable names in an array, and process them by element number, until length-1?
-                  #The future looks good.
-
+                  echo "this URL points to a playlist.  Taking current video."
+                  #Parse text & take URL up to first "&" at "&list=" which points to playlist.
+                  URL=$(echo $URL | awk 'BEGIN { FS="&" } /1/ { print $1 }')
+                  get_stream "$URL"\c
             elif [[ -n $URL ]]; then
                   get_stream "$URL"\c
+                  #echo "Stream does not contain \"&list=\"."
             else
                   echo -e "Please enter a valid URL."
                   exit 0
@@ -171,17 +168,33 @@ case "$opt" in
             esac
             ;;
       -t|--mktag)
-            #this only changes tags for stuff in ytdl-downloads.
-            #Make_ID3_tags changes directories to ytdl-downloads before begining.
-            outfile=$2
-            echo "outfile is $outfile."
-            make_ID3_tags
-            echo "artist: $ARTIST , Title: $TITLE"
+            #this takes 3 args. $1 is the option --mktag.
+            input=$2
+            title=$3
+            artist=$4
+            file=`basename "$input"`
+
+            cd $(dirname "$input")
+            if [ -f /usr/bin/eyeD3 ]; then
+                  #Write the ID3 Tags out with eyeD3.
+                  eyeD3 -t $title -a $artist "$file"
+                  echo "processing \"$file\" with title $title and artist $artist in $(pwd)."
+
+                  #implicit rename. Hard-coded extension appended to ARTIST because
+                  #this script explicitly converts to *.mp3.
+#      FIX FILE RENAME ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓ ↓
+#                 artist=$(echo ${artist}.mp3)          ←
+#                 mv '$file' '$title - $artist'         ←
+#                 echo " '$file' '$title - $artist'"    ←
+#      FIX FILE RENAME ↑ ↑ ↑ ↑ ↑ ↑ ↑ ↑ ↑ ↑ ↑ ↑ ↑ ↑ ↑ ↑ ↑
+            else
+                  echo "please install \"eyeD3\" through python pip."
+            fi
             ;;
       --version)
             echo "Version: " $VERSION
             ;;
-      -ls|--list)
+      -l|--list)
             cd ~/Music/ytdl-downloads/
             echo -e "\n        >>>>>]DOWNLOADED FILES[<<<<<"
             ls -lAh | awk '{$1=$2=$3=$4=$6=$7=$8=""; print $0}'
@@ -197,5 +210,8 @@ case "$opt" in
             ;;
       *|-h|--help)
             display_help
-            ;;
-esac
+            ;; # .
+esac #            \__.-'
+#                /o0 |--.--,--,--.
+#                \_.,'Y_|T_|D_|L_'  Blob Jr.
+#                  `   """""""""


### PR DESCRIPTION
#### Fixed
- --mktag option uses its own mktag routine instead of trying to reuse the one used post-download in  what I call "normal processing" (downloading a stream, and converting.  certain variables populate this way.)
    - This change fixes #3.
    - this new routine uses local variables for title/artist, which are taken in as args instead of read statements like in "normal processing."

#### Added
 - checks for eyeD3's existence here because it's not going through make_ID3_tags() routine anymore.